### PR TITLE
Automate GCP Deployments for Production Environment

### DIFF
--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build and push Docker image (Production)
         run: |
           docker build -t mapster-cloud-production:latest .
-          docker tag mapster-cloud-production:latest gcr.io/containerization-431907/mapster-cloud-prod:latest
+          docker tag mapster-cloud-production:latest gcr.io/containerization-431907/mapster-cloud-production:latest
           docker push gcr.io/containerization-431907/mapster-cloud-production:latest
 
       - name: Deploy to Cloud Run (Production)

--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -31,14 +31,14 @@ jobs:
 
       - name: Build and push Docker image (Production)
         run: |
-          docker build -t mapster-cloud-prod:latest .
-          docker tag mapster-cloud-prod:latest gcr.io/containerization-431907/mapster-cloud-prod:latest
-          docker push gcr.io/containerization-431907/mapster-cloud-prod:latest
+          docker build -t mapster-cloud-production:latest .
+          docker tag mapster-cloud-production:latest gcr.io/containerization-431907/mapster-cloud-prod:latest
+          docker push gcr.io/containerization-431907/mapster-cloud-production:latest
 
       - name: Deploy to Cloud Run (Production)
         run: |
-          gcloud run deploy mapster-service-prod \
-            --image gcr.io/containerization-431907/mapster-cloud-prod:latest \
+          gcloud run deploy mapster-service-production \
+            --image gcr.io/containerization-431907/mapster-cloud-production:latest \
             --platform managed \
             --region europe-west3 \
             --allow-unauthenticated \

--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -1,0 +1,45 @@
+name: GCP Deploy
+
+# on:
+#   push:
+#     branches:
+#       - main
+
+on: [push]
+
+jobs:
+  build-production:
+    runs-on: ubuntu-latest
+    name: Build and Deploy to Production
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GCP_KEYFILE }}' # Same credentials for production
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: containerization-431907 # Same GCP project ID for production
+
+      - name: Authenticate Docker to GCR
+        run: gcloud auth configure-docker
+
+      - name: Build and push Docker image (Production)
+        run: |
+          docker build -t mapster-cloud-prod:latest .
+          docker tag mapster-cloud-prod:latest gcr.io/containerization-431907/mapster-cloud-prod:latest
+          docker push gcr.io/containerization-431907/mapster-cloud-prod:latest
+
+      - name: Deploy to Cloud Run (Production)
+        run: |
+          gcloud run deploy mapster-service-prod \
+            --image gcr.io/containerization-431907/mapster-cloud-prod:latest \
+            --platform managed \
+            --region europe-west3 \
+            --allow-unauthenticated \
+            --set-env-vars DATABASE_URL=${{ secrets.PROD_DATABASE_URL }}

--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -42,4 +42,3 @@ jobs:
             --platform managed \
             --region europe-west3 \
             --allow-unauthenticated \
-            --set-env-vars DATABASE_URL=${{ secrets.PROD_DATABASE_URL }}

--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -1,11 +1,9 @@
 name: GCP Deploy
 
-# on:
-#   push:
-#     branches:
-#       - main
-
-on: [push]
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   build-production:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -3,7 +3,7 @@
 # on:
 #   push:
 #     branches:
-#       - staging
+#       -
 
 # jobs:
 #   build:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,41 +1,41 @@
-# name: GCP Deploy
+name: GCP Deploy
 
-# on:
-#   push:
-#     branches:
-#       -
+on:
+  push:
+    branches:
+      - staging
 
-# jobs:
-#   build:
-#     runs-on: ubuntu-latest
+jobs:
+  build:
+    runs-on: ubuntu-latest
 
-#     steps:
-#       - name: Checkout code
-#         uses: actions/checkout@v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-#       - id: 'auth'
-#         uses: 'google-github-actions/auth@v1'
-#         with:
-#           credentials_json: '${{ secrets.GCP_KEYFILE }}'
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GCP_KEYFILE }}'
 
-#       - name: Set up Cloud SDK
-#         uses: google-github-actions/setup-gcloud@v1
-#         with:
-#           project_id: containerization-431907
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: containerization-431907
 
-#       - name: Authenticate Docker to GCR
-#         run: gcloud auth configure-docker
+      - name: Authenticate Docker to GCR
+        run: gcloud auth configure-docker
 
-#       - name: Build and push Docker image
-#         run: |
-#           docker build -t mapster-cloud:latest .
-#           docker tag mapster-cloud:latest gcr.io/containerization-431907/mapster-cloud:latest
-#           docker push gcr.io/containerization-431907/mapster-cloud:latest
+      - name: Build and push Docker image
+        run: |
+          docker build -t mapster-cloud:latest .
+          docker tag mapster-cloud:latest gcr.io/containerization-431907/mapster-cloud:latest
+          docker push gcr.io/containerization-431907/mapster-cloud:latest
 
-#       - name: Deploy to Cloud Run
-#         run: |
-#           gcloud run deploy mapster-service \
-#             --image gcr.io/containerization-431907/mapster-cloud:latest \
-#             --platform managed \
-#             --region europe-west3 \
-#             --allow-unauthenticated
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy mapster-service \
+            --image gcr.io/containerization-431907/mapster-cloud:latest \
+            --platform managed \
+            --region europe-west3 \
+            --allow-unauthenticated

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,82 +1,41 @@
-name: GCP Deploy
+# name: GCP Deploy
 
 # on:
 #   push:
 #     branches:
 #       - staging
-#       - main # Deploy to production when pushing to main
 
-on: [push]
+# jobs:
+#   build:
+#     runs-on: ubuntu-latest
 
-jobs:
-  build-staging:
-    runs-on: ubuntu-latest
-    name: Build and Deploy to Staging
+#     steps:
+#       - name: Checkout code
+#         uses: actions/checkout@v2
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+#       - id: 'auth'
+#         uses: 'google-github-actions/auth@v1'
+#         with:
+#           credentials_json: '${{ secrets.GCP_KEYFILE }}'
 
-      - id: 'auth'
-        uses: 'google-github-actions/auth@v1'
-        with:
-          credentials_json: '${{ secrets.GCP_KEYFILE }}' # Use the same credentials for both environments
+#       - name: Set up Cloud SDK
+#         uses: google-github-actions/setup-gcloud@v1
+#         with:
+#           project_id: containerization-431907
 
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
-        with:
-          project_id: containerization-431907 # Same GCP project for both environments
+#       - name: Authenticate Docker to GCR
+#         run: gcloud auth configure-docker
 
-      - name: Authenticate Docker to GCR
-        run: gcloud auth configure-docker
+#       - name: Build and push Docker image
+#         run: |
+#           docker build -t mapster-cloud:latest .
+#           docker tag mapster-cloud:latest gcr.io/containerization-431907/mapster-cloud:latest
+#           docker push gcr.io/containerization-431907/mapster-cloud:latest
 
-      - name: Build and push Docker image (Staging)
-        run: |
-          docker build -t mapster-cloud-staging:latest .
-          docker tag mapster-cloud-staging:latest gcr.io/containerization-431907/mapster-cloud-staging:latest
-          docker push gcr.io/containerization-431907/mapster-cloud-staging:latest
-
-      - name: Deploy to Cloud Run (Staging)
-        run: |
-          gcloud run deploy mapster-service-staging \
-            --image gcr.io/containerization-431907/mapster-cloud-staging:latest \
-            --platform managed \
-            --region europe-west3 \
-            --allow-unauthenticated \
-            --set-env-vars DATABASE_URL=${{ secrets.STAGING_DATABASE_URL }}
-
-  build-production:
-    runs-on: ubuntu-latest
-    name: Build and Deploy to Production
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - id: 'auth'
-        uses: 'google-github-actions/auth@v1'
-        with:
-          credentials_json: '${{ secrets.GCP_KEYFILE }}' # Same credentials for production
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
-        with:
-          project_id: containerization-431907 # Same GCP project ID for production
-
-      - name: Authenticate Docker to GCR
-        run: gcloud auth configure-docker
-
-      - name: Build and push Docker image (Production)
-        run: |
-          docker build -t mapster-cloud-prod:latest .
-          docker tag mapster-cloud-prod:latest gcr.io/containerization-431907/mapster-cloud-prod:latest
-          docker push gcr.io/containerization-431907/mapster-cloud-prod:latest
-
-      - name: Deploy to Cloud Run (Production)
-        run: |
-          gcloud run deploy mapster-service-prod \
-            --image gcr.io/containerization-431907/mapster-cloud-prod:latest \
-            --platform managed \
-            --region europe-west3 \
-            --allow-unauthenticated \
-            --set-env-vars DATABASE_URL=${{ secrets.PROD_DATABASE_URL }}
+#       - name: Deploy to Cloud Run
+#         run: |
+#           gcloud run deploy mapster-service \
+#             --image gcr.io/containerization-431907/mapster-cloud:latest \
+#             --platform managed \
+#             --region europe-west3 \
+#             --allow-unauthenticated

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -10,7 +10,6 @@ on: [push]
 
 jobs:
   build-staging:
-    if: github.ref == 'refs/heads/staging' # Trigger only on staging branch
     runs-on: ubuntu-latest
     name: Build and Deploy to Staging
 
@@ -47,7 +46,6 @@ jobs:
             --set-env-vars DATABASE_URL=${{ secrets.STAGING_DATABASE_URL }}
 
   build-production:
-    if: github.ref == 'refs/heads/main' # Trigger only on main branch
     runs-on: ubuntu-latest
     name: Build and Deploy to Production
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,13 +1,18 @@
 name: GCP Deploy
 
-on:
-  push:
-    branches:
-      - staging
+# on:
+#   push:
+#     branches:
+#       - staging
+#       - main # Deploy to production when pushing to main
+
+on: [push]
 
 jobs:
-  build:
+  build-staging:
+    if: github.ref == 'refs/heads/staging' # Trigger only on staging branch
     runs-on: ubuntu-latest
+    name: Build and Deploy to Staging
 
     steps:
       - name: Checkout code
@@ -16,26 +21,64 @@ jobs:
       - id: 'auth'
         uses: 'google-github-actions/auth@v1'
         with:
-          credentials_json: '${{ secrets.GCP_KEYFILE }}'
+          credentials_json: '${{ secrets.GCP_KEYFILE }}' # Use the same credentials for both environments
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1
         with:
-          project_id: containerization-431907
+          project_id: containerization-431907 # Same GCP project for both environments
 
       - name: Authenticate Docker to GCR
         run: gcloud auth configure-docker
 
-      - name: Build and push Docker image
+      - name: Build and push Docker image (Staging)
         run: |
-          docker build -t mapster-cloud:latest .
-          docker tag mapster-cloud:latest gcr.io/containerization-431907/mapster-cloud:latest
-          docker push gcr.io/containerization-431907/mapster-cloud:latest
+          docker build -t mapster-cloud-staging:latest .
+          docker tag mapster-cloud-staging:latest gcr.io/containerization-431907/mapster-cloud-staging:latest
+          docker push gcr.io/containerization-431907/mapster-cloud-staging:latest
 
-      - name: Deploy to Cloud Run
+      - name: Deploy to Cloud Run (Staging)
         run: |
-          gcloud run deploy mapster-service \
-            --image gcr.io/containerization-431907/mapster-cloud:latest \
+          gcloud run deploy mapster-service-staging \
+            --image gcr.io/containerization-431907/mapster-cloud-staging:latest \
             --platform managed \
             --region europe-west3 \
-            --allow-unauthenticated
+            --allow-unauthenticated \
+            --set-env-vars DATABASE_URL=${{ secrets.STAGING_DATABASE_URL }}
+
+  build-production:
+    if: github.ref == 'refs/heads/main' # Trigger only on main branch
+    runs-on: ubuntu-latest
+    name: Build and Deploy to Production
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GCP_KEYFILE }}' # Same credentials for production
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: containerization-431907 # Same GCP project ID for production
+
+      - name: Authenticate Docker to GCR
+        run: gcloud auth configure-docker
+
+      - name: Build and push Docker image (Production)
+        run: |
+          docker build -t mapster-cloud-prod:latest .
+          docker tag mapster-cloud-prod:latest gcr.io/containerization-431907/mapster-cloud-prod:latest
+          docker push gcr.io/containerization-431907/mapster-cloud-prod:latest
+
+      - name: Deploy to Cloud Run (Production)
+        run: |
+          gcloud run deploy mapster-service-prod \
+            --image gcr.io/containerization-431907/mapster-cloud-prod:latest \
+            --platform managed \
+            --region europe-west3 \
+            --allow-unauthenticated \
+            --set-env-vars DATABASE_URL=${{ secrets.PROD_DATABASE_URL }}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -51,7 +51,7 @@
       <!-- LOGIN SCREEN -->
       <section class="container" id="login-screen">
         <div class="container-title">
-          <h1>Mapster Cloud Version 0.2</h1>
+          <h1>Mapster Cloud Version 0.3</h1>
         </div>
         <div class="container-content">
           <form id="login-form">


### PR DESCRIPTION
# ✨ Changes

## 🤖 CI/CD Automation
> Created CI/CD pipeline to perform the following steps every time the `main` branch is updated:

- authenticate using a custom service account for GH actions (credentials stored in GitHub Secrets manager)
- build and tag a container image that combines backend and frontend in one container
- push this container artifact to the GCP Artifact Registry
- Deploy the previously pushed artifact to the Cloud Run Instance